### PR TITLE
Fix error handling - temporary solution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.jboss.qa</groupId>
 			<artifactId>jcontainer-manager</artifactId>
-			<version>1.0.0.Beta1</version>
+			<version>1.0.0.Beta5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/jboss/qa/jenkins/test/executor/phase/cleanup/CleanUpPhaseProcessor.java
+++ b/src/main/java/org/jboss/qa/jenkins/test/executor/phase/cleanup/CleanUpPhaseProcessor.java
@@ -15,9 +15,8 @@
  */
 package org.jboss.qa.jenkins.test.executor.phase.cleanup;
 
-import org.apache.commons.io.FileUtils;
-
 import org.jboss.qa.jenkins.test.executor.JenkinsTestExecutor;
+import org.jboss.qa.jenkins.test.executor.utils.FileUtils;
 import org.jboss.qa.phaser.PhaseDefinitionProcessor;
 
 import java.io.IOException;
@@ -36,7 +35,8 @@ public class CleanUpPhaseProcessor extends PhaseDefinitionProcessor {
 
 		if (cleanUp.cleanWorkspace()) {
 			try {
-				FileUtils.deleteDirectory(JenkinsTestExecutor.WORKSPACE);
+				// Recursive delete except for destinations of symbolic links
+				FileUtils.removeRecursive(JenkinsTestExecutor.WORKSPACE.toPath());
 			} catch (IOException e) {
 				e.printStackTrace();
 			}

--- a/src/main/java/org/jboss/qa/jenkins/test/executor/phase/execution/ExecutionPhaseProcessor.java
+++ b/src/main/java/org/jboss/qa/jenkins/test/executor/phase/execution/ExecutionPhaseProcessor.java
@@ -24,9 +24,9 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class ExecutionPhaseProcessor extends PhaseDefinitionProcessor {
 
-	private Execution maven;
+	private Execution execution;
 
 	public void execute() {
-		log.debug("@{} - {}", Execution.class.getName(), maven.id());
+		log.debug("@{} - {}", Execution.class.getName(), execution.id());
 	}
 }

--- a/src/main/java/org/jboss/qa/jenkins/test/executor/utils/FileUtils.java
+++ b/src/main/java/org/jboss/qa/jenkins/test/executor/utils/FileUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.qa.jenkins.test.executor.utils;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public final class FileUtils {
+	private FileUtils() {
+	}
+
+	public static void removeRecursive(Path path) throws IOException {
+		Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Files.delete(file);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+				// try to delete the file anyway, even if its attributes
+				// could not be read, since delete-only access is
+				// theoretically possible
+				Files.delete(file);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+				if (exc == null) {
+					Files.delete(dir);
+					return FileVisitResult.CONTINUE;
+				} else {
+					// directory iteration failed; propagate exception
+					throw exc;
+				}
+			}
+		});
+	}
+}


### PR DESCRIPTION
Job should fail if any of its executions fails. Error handling should be improved to use exceptions. Now exception handling does not work and process freezes.
- Fix error handling - temporary solution
- Fix cleaning of workspace (symlinks problem)
- Improve MavenCli API
- Update tests
