### PR TITLE
Do not use absolute path to bash program for portability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.jboss.qa</groupId>
 			<artifactId>jcontainer-manager</artifactId>
-			<version>1.0.0.Beta5</version>
+			<version>1.0.0.Beta8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/jboss/qa/jenkins/test/executor/utils/MavenCli.java
+++ b/src/main/java/org/jboss/qa/jenkins/test/executor/utils/MavenCli.java
@@ -156,7 +156,7 @@ public final class MavenCli {
 			cmd.add("/c");
 			cmd.add(mavenHome != null ? mavenHome + File.separator + "bin" + File.separator + "mvn.bat" : "mvn.bat");
 		} else {
-			cmd.add("/bin/bash");
+			cmd.add("bash");
 			cmd.add(mavenHome != null ? mavenHome + File.separator + "bin" + File.separator + "mvn" : "mvn");
 		}
 


### PR DESCRIPTION
- Upgrade jcontainer-manager version
- Closes #18
